### PR TITLE
Add docker images for mmx-node

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,77 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+
+# Automatically cancel previous runs for the same ref (i.e. branch) and event type. The latter component prevents
+# manually dispatched events from being cancelled by pushes to the `master` branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-mmx-node-image:
+    name: Build and push mmx-node image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}-mmx-node
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - final-build-stage: 'base'
+            latest-tag-behaviour: auto
+            version-suffix: ''
+          - final-build-stage: amd
+            latest-tag-behaviour: false
+            version-suffix: '-amd'
+          - final-build-stage: nvidia
+            latest-tag-behaviour: false
+            version-suffix: '-nvidia'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ matrix.latest-tag-behaviour }}
+            suffix=${{ matrix.version-suffix }}
+          tags: |
+            type=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: mmx-node/linux/x86_64
+          target: ${{ matrix.final-build-stage }}
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/mmx-node/linux/x86_64/Dockerfile
+++ b/mmx-node/linux/x86_64/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:22.04 AS base
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y upgrade \
+		&& apt-get install -y \
+			apt-utils \
+			libsecp256k1-0 \
+			librocksdb6.11 \
+			libsodium23 \
+			libminiupnpc17 \
+			libjemalloc2 \
+			zlib1g \
+			libgmp10 \
+			libgomp1 \
+			ocl-icd-libopencl1 \
+			curl \
+			clinfo \
+			&& rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY . .
+
+ENV MMX_HOME="/data/"
+VOLUME /data
+
+# node p2p port
+EXPOSE 12339/tcp
+# http api port
+EXPOSE 11380/tcp
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["./run_node.sh"]
+
+FROM base AS amd
+ARG AMD_DRIVER=amdgpu-install_5.4.50400-1_all.deb
+ARG AMD_DRIVER_URL=https://repo.radeon.com/amdgpu-install/5.4/ubuntu/jammy
+RUN mkdir -p /tmp/opencl-driver-amd \
+    && cd /tmp/opencl-driver-amd \
+    && curl --referer $AMD_DRIVER_URL -O $AMD_DRIVER_URL/$AMD_DRIVER \
+	&& dpkg -i $AMD_DRIVER \
+	&& rm -rf /tmp/opencl-driver-amd
+RUN apt-get update && apt-get -y upgrade \
+		&& apt-get install -y \
+			rocm-opencl \
+			&& rm -rf /var/lib/apt/lists/*
+
+FROM base AS nvidia
+RUN apt-get update && apt-get -y upgrade \
+		&& apt-get install -y \
+			nvidia-driver-470 \
+			&& rm -rf /var/lib/apt/lists/*

--- a/mmx-node/linux/x86_64/docker-entrypoint.sh
+++ b/mmx-node/linux/x86_64/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -em
+
+source ./activate.sh
+
+"$@"


### PR DESCRIPTION
Similarly to https://github.com/madMAx43v3r/mmx-node/pull/162 this PR will add docker images which will be built based on the same rules, but with the closed source binaries of this repo.

`edge`, `edge-amd` and `edge-nvidia` are available on master pushes, semver tags have their own tagged docker images based on major, major.minor and major.miner.patch tags, all with the respective amd or nvidia suffix applied.