### PR TITLE
Fix nvidia docker image

### DIFF
--- a/mmx-node/linux/overlay/x86_64/Dockerfile
+++ b/mmx-node/linux/overlay/x86_64/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get -y upgrade \
 			&& rm -rf /var/lib/apt/lists/*
 
 FROM base AS nvidia
-RUN apt-get update && apt-get -y upgrade \
-		&& apt-get install -y \
-			nvidia-driver-470 \
-			&& rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/OpenCL/vendors \
+    && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility


### PR DESCRIPTION
Currently the nvidia image installs a nvidia driver which is not needed, instead we just need to set some environment variables and edit the opencl loader to make it work.